### PR TITLE
28 interface nomenclature rather than direction

### DIFF
--- a/examples/tbdex.dwnp.yml
+++ b/examples/tbdex.dwnp.yml
@@ -1,7 +1,7 @@
 definition: "https://raw.githubusercontent.com/TBD54566975/tbdex-protocol/kendall/remote-url-definition/js/src/tbdex.json"
 routes:
   - description: "Inbound Offering query"
-    direction: "INBOUND"
+    interface: "DwnRequest"
     match:
       interface: "Records"
       method: "Query"
@@ -13,7 +13,7 @@ routes:
           endpoint: "http://0.0.0.0:3001/tbdex/offers"
           published: true
   - description: "Inbound RFQ"
-    direction: "INBOUND"
+    interface: "DwnRequest"
     match:
       interface: "Records"
       method: "Write"
@@ -27,7 +27,7 @@ routes:
           method: "PUT"
           endpoint: "http://0.0.0.0:3001/tbdex/rfq"
   - description: "Outbound Quote"
-    direction: "OUTBOUND"
+    interface: "Restful"
     method: "PUT"
     path: "/quote"
     actions:
@@ -49,7 +49,7 @@ routes:
           parentId: "#1.recordId"
           contextId: "#1.contextId"
   - description: "Outbound Order Status"
-    direction: "OUTBOUND"
+    interface: "Restful"
     method: "PUT"
     path: "/order-status"
     actions:

--- a/src/dwn-proxy-cli.ts
+++ b/src/dwn-proxy-cli.ts
@@ -138,7 +138,7 @@ export const main = async () => {
   for (const route of config.routes) {
     console.log('Configuring route', route.description)
 
-    if (route.direction === 'INBOUND') {
+    if (route.interface === 'DwnRequest') {
       proxy.addHandler(
         dwnRequest =>
           Object.entries(route.match).every(([key, value]) => {
@@ -172,7 +172,7 @@ export const main = async () => {
           throw new Error(`Never replied to client`)
         }
       )
-    } else if (route.direction === 'OUTBOUND') {
+    } else if (route.interface === 'Restul') {
       proxy.server.api.put(
         route.path, async (req, res) => {
           let populatePool = { '#body': await readReq(req) }
@@ -193,7 +193,7 @@ export const main = async () => {
           res.end()
         })
     } else {
-      throw new Error(`Route direction unsupported ${route.direction}`)
+      throw new Error(`Route interface unsupported ${route.interface}`)
     }
   }
 }


### PR DESCRIPTION
https://github.com/TBD54566975/dwn-proxy-js/issues/28

FYI @michaelneale I didn't like the `INBOUND` vs `OUTBOUND` because there nothing to say that an incoming DwnRequest may not necessary bounce back out with an outbound DWN Message. Same with outbound, it's just a restful API, so there's no reason that it must necessary consist of an outbound DWN Message.

_So rather than direction: INBOUND do an interface: DwnRequest_

_And then rather than direction: OUTBOUND do an interface: Restful_